### PR TITLE
Json fix for special characters causing malformed response

### DIFF
--- a/app/controllers/resumes_controller.rb
+++ b/app/controllers/resumes_controller.rb
@@ -73,15 +73,28 @@ class ResumesController < ApplicationController
 
   def get_summary_by_id
     unless params[:id].nil?
-      @resume         = Resume.find_by_id(params[:id])
-      unless @resume.nil?
-        render "summary_json", :layout => false
+      @resume = Resume.find_by_id(params[:id])
+  
+      if @resume.present?
+        respond_to do |format|
+          format.json do
+            render json: {
+              name: @resume.name,
+              uniqid: @resume.uniqid.name,
+              status: @resume.resume_overall_status,
+              summary: @resume.summary,
+              email: @resume.email,
+              phone: @resume.phone,
+              notice: @resume.notice
+            }
+          end
+        end
       else
-	render :text => "No such resume", :status => 403
+        render text: "No such resume", status: 403
         return
       end
     else
-      render :text => "Empty resume id", :status => 403
+      render text: "Empty resume id", status: 403
       return
     end
   end

--- a/app/views/resumes/summary_json.html.erb
+++ b/app/views/resumes/summary_json.html.erb
@@ -1,9 +1,0 @@
-{
-  "name" : "<%= @resume.name %>", 
-  "uniqid" : "<%= @resume.uniqid.name %>", 
-  "status" : "<%= @resume.resume_overall_status %>", 
-  "summary" : "<%= @resume.summary %>",
-  "email" : "<%= @resume.email%>",
-  "phone" : "<%= @resume.phone%>",
-  "notice" : "<%= @resume.notice%>"
-}


### PR DESCRIPTION
Escape special characters in text, for examples below

```
"summary" : "Palladium and Veloce --3yrs lwd:May 11th other DOJ:May 5th”

“summary” : "LWD - Feb 8th || Client - Intel, AMD\r\n”
```