### PR TITLE
Send weekly reminder mails to TA Leads instead of Hiring mgr

### DIFF
--- a/app/assets/javascripts/open_requirements_grid.js
+++ b/app/assets/javascripts/open_requirements_grid.js
@@ -1,4 +1,3 @@
-// This registers the module correctly from the single loaded file
 agGrid.ModuleRegistry.registerModules([agGrid.ClientSideRowModelModule]);
 
 document.addEventListener('turbolinks:load', () => {
@@ -138,6 +137,12 @@ document.addEventListener('turbolinks:load', () => {
       },
       components: {
         linkCellRenderer: LinkCellRenderer
+      },
+      onGridReady: (params) => {
+          updateRowCount(params.api);
+      },
+      onModelUpdated: (params) => {
+          updateRowCount(params.api);
       }
     };
     
@@ -201,3 +206,11 @@ document.addEventListener('turbolinks:load', () => {
     };
   }
 });
+
+function updateRowCount(api) {
+    const rowCount = api.getDisplayedRowCount();
+    const rowCountDisplay = document.getElementById('record-count-display');
+    if (rowCountDisplay) {
+        rowCountDisplay.textContent = rowCount;
+    }
+}

--- a/app/mailers/emailer.rb
+++ b/app/mailers/emailer.rb
@@ -274,12 +274,12 @@ class Emailer < ApplicationMailer
     mail(to: recipients, subject: subject) if recipients.length > 0
   end
 
-  # Weekly summary mail to Hiring Managers listing requirements pending review
-  def weekly_hm_requirement_summary(hiring_manager, requirements)
-    @hiring_manager = hiring_manager
+  # Weekly summary mail to TA lead listing requirements pending review
+  def weekly_ta_requirement_summary(ta_lead, requirements)
+    @ta_lead = ta_lead
     @requirements = requirements
     subject = "Weekly Pending Requirement Review Summary"
-    mail(to: hiring_manager.email, subject: subject)
+    mail(to: ta_lead.email, subject: subject)
   end
 
   def feedback_reminder(interview)

--- a/app/views/emailer/weekly_ta_requirement_summary.html.erb
+++ b/app/views/emailer/weekly_ta_requirement_summary.html.erb
@@ -1,4 +1,4 @@
-<p>Dear <%= @hiring_manager.name %>,</p>
+<p>Dear <%= @ta_lead.name %>,</p>
 
 <p>Here is your weekly summary of requirements pending review (open > 3 business days with no projection):</p>
 
@@ -9,6 +9,7 @@
       <th>Status</th>
       <th>Engineering Leads</th>
       <th>TA Leads</th>
+      <th>Hiring Mgr</th>
       <th>Last Forward Received</th>
       <th>Open Forwards</th>
       <th>Shortlisted</th>
@@ -22,6 +23,7 @@
         <td><%= req.status %></td>
         <td><%= req.eng_leads.map(&:name).join(', ') %></td>
         <td><%= req.ta_leads.map(&:name).join(', ') %></td>
+        <td><%= req.employee&.name %></td>
         <td><%= req.last_forward_recieved.strftime('%d/%m/%Y') %></td>
         <td><%= req.open_forwards.count %></td>
         <td><%= req.shortlists.count %></td>

--- a/app/views/requirements/index.html.erb
+++ b/app/views/requirements/index.html.erb
@@ -18,7 +18,8 @@
     <div style="display: flex; align-items: center;">
       Search:
       <input type="text" id="quickFilterInput" placeholder="Type to search..." style="margin-right: 10px;">
-      <button onclick="window.clearAllFilters()">Clear All Filters</button>
+      <button onclick="window.clearAllFilters()">Clear All Filters</button> &nbsp;
+      <span>(<span id="record-count-display">0</span> records)</span>
     </div>
     <div style="display: flex; align-items: center; gap: 20px;">
       <span>

--- a/lib/tasks/send_requirement_reminders.rake
+++ b/lib/tasks/send_requirement_reminders.rake
@@ -13,24 +13,24 @@ end
 
 # rake weekly:hm_requirement_summary
 namespace :weekly do
-  desc 'Send weekly summary to Hiring Managers for requirements open > 3 business days with no projection'
-  task :hm_requirement_summary => :environment do
+  desc 'Send weekly summary to TA Leads for requirements open > 3 business days with no projection'
+  task :ta_requirement_summary => :environment do
 
     # Build HM => [requirements] mapping
-    hm_to_requirements = Hash.new { |h, k| h[k] = [] }
+    ta_to_requirements = Hash.new { |h, k| h[k] = [] }
     open_requirements = Requirement.where(status: ['OPEN', 'HOLD'])
     open_requirements.each do |requirement|
-      next if requirement.employee.nil? # HM must exist
+      next if requirement.ta_leads.size == 0 # TA Leads must exist
       no_of_business_days = business_days_between(requirement.last_forward_recieved, Date.today)
-
       next if no_of_business_days <= 3
-      hm_to_requirements[requirement.employee] << requirement
+      requirement.ta_leads.each do |lead|
+        ta_to_requirements[lead] << requirement
+      end
     end
-
-    hm_to_requirements.each do |hm, reqs|
+    ta_to_requirements.each do |ta, reqs|
       next if reqs.size == 0
-      Emailer.weekly_hm_requirement_summary(hm, reqs).deliver_now
-      puts "Sent weekly HM summary to #{hm.name} (#{hm.email}) with #{reqs.size} requirement(s)."
+      Emailer.weekly_ta_requirement_summary(ta, reqs).deliver_now
+      puts "Sent weekly TA Lead summary to #{ta.name} (#{ta.email}) with #{reqs.size} requirement(s)."
     end
   end
 end


### PR DESCRIPTION
- Display live row count of Requirements table
- Modify rake task to send weekly reminder mails to TA Leads instead of Hiring mgr.